### PR TITLE
[codex] Improve Containerfile queries

### DIFF
--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -6,5 +6,7 @@ test("can load grammar", async () => {
     const { default: binding } = await import("./index.js");
     assert.ok(binding.language);
     assert.ok(Array.isArray(binding.nodeTypeInfo));
+    assert.ok(binding.HIGHLIGHTS_QUERY);
+    assert.ok(binding.INJECTIONS_QUERY);
   });
 });

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -10,3 +10,7 @@ class TestLanguage(TestCase):
             Parser(Language(tree_sitter_containerfile.language()))
         except Exception:
             self.fail("Error loading Containerfile grammar")
+
+    def test_can_load_queries(self):
+        self.assertTrue(tree_sitter_containerfile.HIGHLIGHTS_QUERY)
+        self.assertTrue(tree_sitter_containerfile.INJECTIONS_QUERY)

--- a/bindings/python/tree_sitter_containerfile/__init__.py
+++ b/bindings/python/tree_sitter_containerfile/__init__.py
@@ -14,8 +14,8 @@ def _get_query(name, file):
 def __getattr__(name):
     if name == "HIGHLIGHTS_QUERY":
         return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
-    # if name == "INJECTIONS_QUERY":
-    #     return _get_query("INJECTIONS_QUERY", "injections.scm")
+    if name == "INJECTIONS_QUERY":
+        return _get_query("INJECTIONS_QUERY", "injections.scm")
     # if name == "LOCALS_QUERY":
     #     return _get_query("LOCALS_QUERY", "locals.scm")
     # if name == "TAGS_QUERY":
@@ -27,7 +27,7 @@ def __getattr__(name):
 __all__ = [
     "language",
     "HIGHLIGHTS_QUERY",
-    # "INJECTIONS_QUERY",
+    "INJECTIONS_QUERY",
     # "LOCALS_QUERY",
     # "TAGS_QUERY",
 ]

--- a/queries.go
+++ b/queries.go
@@ -10,6 +10,9 @@ import (
 //go:embed queries/highlights.scm
 var HighlightsQuery string
 
+//go:embed queries/injections.scm
+var InjectionsQuery string
+
 // GetLanguage returns the tree-sitter Language for Containerfile.
 func GetLanguage() *sitter.Language {
 	return sitter.NewLanguage(binding.Language())
@@ -18,4 +21,9 @@ func GetLanguage() *sitter.Language {
 // GetHighlightsQuery compiles and returns the bundled highlights query.
 func GetHighlightsQuery() (*sitter.Query, *sitter.QueryError) {
 	return sitter.NewQuery(GetLanguage(), HighlightsQuery)
+}
+
+// GetInjectionsQuery compiles and returns the bundled injections query.
+func GetInjectionsQuery() (*sitter.Query, *sitter.QueryError) {
+	return sitter.NewQuery(GetLanguage(), InjectionsQuery)
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,57 +1,80 @@
 [
-	"FROM"
-	"AS"
-	"RUN"
-	"CMD"
-	"LABEL"
-	"EXPOSE"
-	"ENV"
-	"ADD"
-	"COPY"
-	"ENTRYPOINT"
-	"VOLUME"
-	"USER"
-	"WORKDIR"
-	"ARG"
-	"ONBUILD"
-	"STOPSIGNAL"
-	"HEALTHCHECK"
-	"SHELL"
-	"MAINTAINER"
-	"CROSS_BUILD"
-	(heredoc_marker)
-	(heredoc_end)
+  "FROM"
+  "AS"
+  "RUN"
+  "CMD"
+  "LABEL"
+  "EXPOSE"
+  "ENV"
+  "ADD"
+  "COPY"
+  "ENTRYPOINT"
+  "VOLUME"
+  "USER"
+  "WORKDIR"
+  "ARG"
+  "ONBUILD"
+  "STOPSIGNAL"
+  "HEALTHCHECK"
+  "SHELL"
+  "MAINTAINER"
+  "CROSS_BUILD"
 ] @keyword
 
 [
-	":"
-	"@"
+  ":"
+  "@"
 ] @operator
 
-(comment) @comment
-
+(comment) @comment @spell
 
 (image_spec
-	(image_tag
-		":" @punctuation.special)
-	(image_digest
-		"@" @punctuation.special))
+  (image_tag
+    ":" @punctuation.special)
+  (image_digest
+    "@" @punctuation.special))
 
 [
-	(double_quoted_string)
-	(single_quoted_string)
-	(json_string)
-	(heredoc_block)
+  (double_quoted_string)
+  (single_quoted_string)
+  (json_string)
 ] @string
+
+(heredoc_block) @string
+
+[
+  (heredoc_marker)
+  (heredoc_end)
+] @label
+
+(escape_sequence) @string.escape
 
 (expansion
   [
-	"$"
-	"{"
-	"}"
+    "$"
+    "{"
+    "}"
   ] @punctuation.special
-) @none
+)
 
 ((variable) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
+(arg_instruction
+  name: (unquoted_string) @property)
+
+(env_pair
+  name: (unquoted_string) @property)
+
+(label_pair
+  key: (_) @property)
+
+(param
+  name: (_) @property)
+
+(mount_param
+  name: (_) @property)
+
+(mount_param_param) @property
+
+(expose_port) @number

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,11 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((shell_command) @injection.content
+  (#set! injection.language "bash")
+  (#set! injection.combined))
+
+((run_instruction
+  (heredoc_block) @injection.content)
+  (#set! injection.language "bash")
+  (#set! injection.include-children))

--- a/queries_test.go
+++ b/queries_test.go
@@ -33,3 +33,30 @@ func TestHighlightsQueryCompiles(t *testing.T) {
 		t.Errorf("expected keyword capture, got: %v", names)
 	}
 }
+
+func TestInjectionsQueryCompiles(t *testing.T) {
+	if containerfile.InjectionsQuery == "" {
+		t.Fatal("InjectionsQuery is empty")
+	}
+	query, err := containerfile.GetInjectionsQuery()
+	if err != nil {
+		t.Fatalf("injections query failed to compile: %v", err)
+	}
+	defer query.Close()
+
+	names := query.CaptureNames()
+	if len(names) == 0 {
+		t.Fatal("injections query has no captures")
+	}
+
+	found := false
+	for _, name := range names {
+		if name == "injection.content" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected injection.content capture, got: %v", names)
+	}
+}

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -17,6 +17,9 @@
       "highlights": [
         "queries/highlights.scm"
       ],
+      "injections": [
+        "queries/injections.scm"
+      ],
       "injection-regex": "^(containerfile|dockerfile|docker|container)$"
     }
   ],


### PR DESCRIPTION
## Summary

- Expand `queries/highlights.scm` with richer captures adapted from `neovim-treesitter/nvim-treesitter-queries-dockerfile`, while keeping portable `#match?` predicates instead of nvim-only Lua predicates.
- Add `queries/injections.scm` for comments, shell commands, and `RUN` heredoc blocks.
- Expose and compile-check the injections query through Go, Node, Python, and Rust packaging surfaces where applicable.

## Notes

The local grammar does not expose nvim's named `shell_fragment` or `heredoc_line` nodes, so the injection query targets the compatible `shell_command` and `heredoc_block` nodes without changing parse trees.

## Validation

- `go test ./...`
- `npm test`
- `npm run lint && npm run typecheck`
- `cargo test`
- `npx tree-sitter test`
- `tree-sitter query -q queries/highlights.scm /tmp/query-check.Dockerfile`
- `tree-sitter query -q queries/injections.scm /tmp/query-check.Dockerfile`
- `/tmp/tree-sitter-containerfile-venv/bin/python -m pytest bindings/python/tests`