### PR TITLE
[codex] Add clang-tidy scanner CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: >
   -*,
   clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
   bugprone-*,
   cert-*,
   performance-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,4 @@ Checks: >
   -bugprone-signed-char-misuse,
   -cert-str34-c
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
-ExcludeHeaderFilterRegex: '.*/src/tree_sitter/.*'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,17 @@
+---
+Checks: >
+  -*,
+  clang-analyzer-*,
+  bugprone-*,
+  cert-*,
+  performance-*,
+  portability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-signed-char-misuse,
+  -cert-str34-c
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+ExcludeHeaderFilterRegex: '.*/src/tree_sitter/.*'
+FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,8 @@ Checks: >
   cert-*,
   performance-*,
   portability-*,
+  readability-*,
+  modernize-*,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^$'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,9 @@ Checks: >
   portability-*,
   readability-*,
   modernize-*,
+  misc-unused-parameters,
+  misc-redundant-expression,
+  misc-misleading-identifier,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^$'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,10 +7,6 @@ Checks: >
   cert-*,
   performance-*,
   portability-*,
-  -bugprone-easily-swappable-parameters,
-  -bugprone-macro-parentheses,
-  -bugprone-narrowing-conversions,
-  -bugprone-signed-char-misuse,
-  -cert-str34-c
 WarningsAsErrors: '*'
+HeaderFilterRegex: '^$'
 FormatStyle: file

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,31 @@
+name: Clang-Tidy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - src/scanner.c
+      - .clang-tidy
+      - .github/workflows/clang-tidy.yml
+  pull_request:
+    paths:
+      - src/scanner.c
+      - .clang-tidy
+      - .github/workflows/clang-tidy.yml
+
+jobs:
+  scanner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy
+      - name: Show clang-tidy version
+        run: clang-tidy --version
+      - name: Verify clang-tidy config
+        run: clang-tidy --verify-config
+      - name: Run clang-tidy on scanner
+        run: clang-tidy src/scanner.c -- -std=c11 -Isrc

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,17 +15,32 @@ on:
 
 jobs:
   scanner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install clang-tidy
+      - name: Select latest clang-tidy
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-tidy
+          set -euo pipefail
+          latest_clang_tidy="$(
+            { compgen -c clang-tidy- || true; } \
+              | sed -n 's/^clang-tidy-\([0-9][0-9]*\)$/\1 clang-tidy-\1/p' \
+              | sort -nr \
+              | awk 'NR == 1 { print $2 }'
+          )"
+          if [ -z "$latest_clang_tidy" ]; then
+            latest_clang_tidy="$(command -v clang-tidy || true)"
+          fi
+          if [ -z "$latest_clang_tidy" ]; then
+            echo "::error::No clang-tidy executable found on the runner"
+            exit 1
+          fi
+          echo "CLANG_TIDY=$latest_clang_tidy" >> "$GITHUB_ENV"
+          echo "Selected $latest_clang_tidy"
       - name: Show clang-tidy version
-        run: clang-tidy --version
+        run: '"$CLANG_TIDY" --version'
       - name: Verify clang-tidy config
-        run: clang-tidy --verify-config
+        run: '"$CLANG_TIDY" --verify-config'
       - name: Run clang-tidy on scanner
-        run: clang-tidy src/scanner.c -- -std=c11 -Isrc
+        run: '"$CLANG_TIDY" src/scanner.c -- -std=c11 -Isrc'

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -31,6 +31,23 @@ enum TokenType {
     ERROR_SENTINEL,
 };
 
+typedef struct {
+    const char *key;
+    unsigned key_len;
+    int32_t value;
+    unsigned value_len;
+} parser_directive;
+
+static char serialize_bool(bool value) { return value ? '\1' : '\0'; }
+
+static bool deserialize_bool(char value) { return value != '\0'; }
+
+static char serialize_char(int32_t value) { return (char)(unsigned char)value; }
+
+static int32_t deserialize_char(char value) {
+    return (int32_t)(unsigned char)value;
+}
+
 void *tree_sitter_containerfile_external_scanner_create() {
     scanner_state *state = malloc(sizeof(scanner_state));
     if (!state)
@@ -69,12 +86,12 @@ unsigned tree_sitter_containerfile_external_scanner_serialize(void *payload,
     scanner_state *state = payload;
 
     unsigned pos = 0;
-    buffer[pos++] = state->in_heredoc;
-    buffer[pos++] = state->stripping_heredoc;
-    buffer[pos++] = state->directive_allowed;
-    buffer[pos++] = state->escape_seen;
-    buffer[pos++] = state->at_line_start;
-    buffer[pos++] = (char)state->escape_char;
+    buffer[pos++] = serialize_bool(state->in_heredoc);
+    buffer[pos++] = serialize_bool(state->stripping_heredoc);
+    buffer[pos++] = serialize_bool(state->directive_allowed);
+    buffer[pos++] = serialize_bool(state->escape_seen);
+    buffer[pos++] = serialize_bool(state->at_line_start);
+    buffer[pos++] = serialize_char(state->escape_char);
 
     for (unsigned i = 0; i < state->heredoc_count; i++) {
         // Add the ending null byte to the length since we'll have to copy it as
@@ -112,13 +129,13 @@ void tree_sitter_containerfile_external_scanner_deserialize(void *payload,
         return;
     } else {
         unsigned pos = 0;
-        state->in_heredoc = buffer[pos++];
-        state->stripping_heredoc = buffer[pos++];
+        state->in_heredoc = deserialize_bool(buffer[pos++]);
+        state->stripping_heredoc = deserialize_bool(buffer[pos++]);
 
-        state->directive_allowed = buffer[pos++];
-        state->escape_seen = buffer[pos++];
-        state->at_line_start = buffer[pos++];
-        state->escape_char = buffer[pos++];
+        state->directive_allowed = deserialize_bool(buffer[pos++]);
+        state->escape_seen = deserialize_bool(buffer[pos++]);
+        state->at_line_start = deserialize_bool(buffer[pos++]);
+        state->escape_char = deserialize_char(buffer[pos++]);
         if (state->escape_char != '\\' && state->escape_char != '`') {
             state->escape_char = '\\';
         }
@@ -289,22 +306,24 @@ static bool scan_line_continuation(scanner_state *state, TSLexer *lexer,
     return true;
 }
 
-static bool is_parser_directive(scanner_state *state, const char *key,
-                                unsigned key_len, int32_t value,
-                                unsigned value_len) {
-    if (key_len == 6 && memcmp(key, "escape", 6) == 0) {
-        if (value_len != 1 || state->escape_seen ||
-            (value != '\\' && value != '`')) {
+static bool is_parser_directive(scanner_state *state,
+                                const parser_directive *directive) {
+    if (directive->key_len == 6 &&
+        memcmp(directive->key, "escape", 6) == 0) {
+        if (directive->value_len != 1 || state->escape_seen ||
+            (directive->value != '\\' && directive->value != '`')) {
             return false;
         }
-        state->escape_char = value;
+        state->escape_char = directive->value;
         state->escape_seen = true;
         return true;
     }
 
-    return value_len > 0 &&
-           ((key_len == 6 && memcmp(key, "syntax", 6) == 0) ||
-            (key_len == 5 && memcmp(key, "check", 5) == 0));
+    return directive->value_len > 0 &&
+           ((directive->key_len == 6 &&
+             memcmp(directive->key, "syntax", 6) == 0) ||
+            (directive->key_len == 5 &&
+             memcmp(directive->key, "check", 5) == 0));
 }
 
 static bool scan_comment(scanner_state *state, TSLexer *lexer) {
@@ -369,8 +388,13 @@ static bool scan_comment(scanner_state *state, TSLexer *lexer) {
     }
 
     if (may_be_directive && key_len < sizeof(key)) {
-        directive =
-            is_parser_directive(state, key, key_len, value, value_len);
+        const parser_directive candidate = {
+            .key = key,
+            .key_len = key_len,
+            .value = value,
+            .value_len = value_len,
+        };
+        directive = is_parser_directive(state, &candidate);
     }
 
     if (!directive && state->directive_allowed) {
@@ -431,7 +455,7 @@ static bool scan_marker(scanner_state *state, TSLexer *lexer) {
         }
 
         if (del_idx > 0) {
-            delimiter[del_idx++] = lexer->lookahead;
+            delimiter[del_idx++] = serialize_char(lexer->lookahead);
         }
         lexer->advance(lexer, false);
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -5,8 +5,15 @@
 
 #include "tree_sitter/parser.h"
 
-#define MAX_HEREDOCS 10
-#define DEL_SPACE 512
+enum {
+    MAX_HEREDOCS = 10,
+    DEL_SPACE = 512,
+    SERIALIZED_HEADER_SIZE = 6,
+    DIRECTIVE_KEY_CAPACITY = 16,
+    CHECK_DIRECTIVE_LEN = 5,
+    ESCAPE_DIRECTIVE_LEN = 6,
+    SYNTAX_DIRECTIVE_LEN = 6,
+};
 
 typedef struct {
     bool in_heredoc;
@@ -38,7 +45,12 @@ typedef struct {
     unsigned value_len;
 } parser_directive;
 
-static char serialize_bool(bool value) { return value ? '\1' : '\0'; }
+static char serialize_bool(bool value) {
+    if (value) {
+        return (char)1;
+    }
+    return (char)0;
+}
 
 static bool deserialize_bool(char value) { return value != '\0'; }
 
@@ -50,8 +62,9 @@ static int32_t deserialize_char(char value) {
 
 void *tree_sitter_containerfile_external_scanner_create() {
     scanner_state *state = malloc(sizeof(scanner_state));
-    if (!state)
+    if (!state) {
         return NULL;
+    }
     memset(state, 0, sizeof(scanner_state));
     state->directive_allowed = true;
     state->at_line_start = true;
@@ -73,8 +86,9 @@ static void clear_heredocs(scanner_state *state) {
 }
 
 void tree_sitter_containerfile_external_scanner_destroy(void *payload) {
-    if (!payload)
+    if (!payload) {
         return;
+    }
 
     scanner_state *state = payload;
     clear_heredocs(state);
@@ -125,72 +139,87 @@ void tree_sitter_containerfile_external_scanner_deserialize(void *payload,
     state->at_line_start = true;
     state->escape_char = '\\';
 
-    if (length < 6) {
+    if (length < SERIALIZED_HEADER_SIZE) {
         return;
-    } else {
-        unsigned pos = 0;
-        state->in_heredoc = deserialize_bool(buffer[pos++]);
-        state->stripping_heredoc = deserialize_bool(buffer[pos++]);
-
-        state->directive_allowed = deserialize_bool(buffer[pos++]);
-        state->escape_seen = deserialize_bool(buffer[pos++]);
-        state->at_line_start = deserialize_bool(buffer[pos++]);
-        state->escape_char = deserialize_char(buffer[pos++]);
-        if (state->escape_char != '\\' && state->escape_char != '`') {
-            state->escape_char = '\\';
-        }
-
-        unsigned heredoc_count = 0;
-        for (unsigned i = 0; i < MAX_HEREDOCS && pos < length; i++) {
-            const char *end = memchr(&buffer[pos], '\0', length - pos);
-            if (!end)
-                break;
-
-            unsigned len = end - &buffer[pos];
-
-            // We found the ending null byte which means that we're done.
-            if (len == 0)
-                break;
-
-            // Account for the ending null byte in strings (again).
-            len++;
-            char *heredoc = malloc(len);
-            if (!heredoc)
-                break;
-            memcpy(heredoc, &buffer[pos], len);
-            state->heredocs[i] = heredoc;
-            heredoc_count++;
-
-            pos += len;
-        }
-
-        state->heredoc_count = heredoc_count;
     }
+
+    unsigned pos = 0;
+    state->in_heredoc = deserialize_bool(buffer[pos++]);
+    state->stripping_heredoc = deserialize_bool(buffer[pos++]);
+
+    state->directive_allowed = deserialize_bool(buffer[pos++]);
+    state->escape_seen = deserialize_bool(buffer[pos++]);
+    state->at_line_start = deserialize_bool(buffer[pos++]);
+    state->escape_char = deserialize_char(buffer[pos++]);
+    if (state->escape_char != '\\' && state->escape_char != '`') {
+        state->escape_char = '\\';
+    }
+
+    unsigned heredoc_count = 0;
+    for (unsigned i = 0; i < MAX_HEREDOCS && pos < length; i++) {
+        const char *end = memchr(&buffer[pos], '\0', length - pos);
+        if (!end) {
+            break;
+        }
+
+        unsigned len = end - &buffer[pos];
+
+        // We found the ending null byte which means that we're done.
+        if (len == 0) {
+            break;
+        }
+
+        // Account for the ending null byte in strings (again).
+        len++;
+        char *heredoc = malloc(len);
+        if (!heredoc) {
+            break;
+        }
+        memcpy(heredoc, &buffer[pos], len);
+        state->heredocs[i] = heredoc;
+        heredoc_count++;
+
+        pos += len;
+    }
+
+    state->heredoc_count = heredoc_count;
 }
 
-static bool is_inline_space(int32_t c) {
-    return c != '\0' && c != '\n' && c != '\r' && iswspace(c);
+static bool is_inline_space(int32_t codepoint) {
+    return (codepoint != '\0' && codepoint != '\n' && codepoint != '\r' &&
+            iswspace(codepoint) != 0) != 0;
 }
 
-static bool is_directive_space(int32_t c) { return c == ' ' || c == '\t'; }
+static bool is_directive_space(int32_t codepoint) {
+    return (codepoint == ' ' || codepoint == '\t') != 0;
+}
 
-static int32_t to_lower_ascii(int32_t c) {
-    return c >= 'A' && c <= 'Z' ? c - 'A' + 'a' : c;
+static bool is_ascii_alpha(int32_t codepoint) {
+    return ((codepoint >= 'a' && codepoint <= 'z') ||
+            (codepoint >= 'A' && codepoint <= 'Z')) != 0;
+}
+
+static int32_t to_lower_ascii(int32_t codepoint) {
+    return codepoint >= 'A' && codepoint <= 'Z'
+               ? codepoint - 'A' + 'a'
+               : codepoint;
 }
 
 static bool is_line_end(TSLexer *lexer) {
-    return lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
-           lexer->eof(lexer);
+    return (lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
+            lexer->eof(lexer)) != 0;
 }
 
 static void skip_inline_whitespace(TSLexer *lexer) {
-    while (is_inline_space(lexer->lookahead))
+    while (is_inline_space(lexer->lookahead)) {
         lexer->advance(lexer, true);
+    }
 }
 
 static void skip_leading_tabs(TSLexer *lexer) {
-    while (lexer->lookahead == '\t')
+    while (lexer->lookahead == '\t') {
         lexer->advance(lexer, true);
+    }
 }
 
 static void push_heredoc(scanner_state *state, char *delimiter) {
@@ -206,8 +235,9 @@ static void push_heredoc(scanner_state *state, char *delimiter) {
 }
 
 static void pop_heredoc(scanner_state *state) {
-    if (state->heredoc_count == 0)
+    if (state->heredoc_count == 0) {
         return;
+    }
 
     free(state->heredocs[0]);
 
@@ -232,8 +262,9 @@ static void close_directive_prologue(scanner_state *state) {
 static bool scan_newline(scanner_state *state, TSLexer *lexer, int symbol) {
     if (lexer->lookahead == '\r') {
         lexer->advance(lexer, false);
-        if (lexer->lookahead == '\n')
+        if (lexer->lookahead == '\n') {
             lexer->advance(lexer, false);
+        }
     } else if (lexer->lookahead == '\n') {
         lexer->advance(lexer, false);
     } else {
@@ -261,8 +292,9 @@ static bool scan_line_continuation(scanner_state *state, TSLexer *lexer,
 
     skip_inline_whitespace(lexer);
 
-    if (lexer->lookahead != state->escape_char)
+    if (lexer->lookahead != state->escape_char) {
         return false;
+    }
 
     lexer->advance(lexer, false);
 
@@ -274,22 +306,26 @@ static bool scan_line_continuation(scanner_state *state, TSLexer *lexer,
 
         if (lexer->lookahead == '\r') {
             lexer->advance(lexer, false);
-            if (lexer->lookahead == '\n')
+            if (lexer->lookahead == '\n') {
                 lexer->advance(lexer, false);
+            }
         } else {
             lexer->advance(lexer, false);
         }
         return true;
     }
 
-    if (!valid_symbols[LINE_CONTINUATION])
+    if (!valid_symbols[LINE_CONTINUATION]) {
         return false;
+    }
 
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\t')
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
         lexer->advance(lexer, false);
+    }
 
-    if (lexer->lookahead != '\n' && lexer->lookahead != '\r')
+    if (lexer->lookahead != '\n' && lexer->lookahead != '\r') {
         return false;
+    }
 
     close_directive_prologue(state);
     state->at_line_start = true;
@@ -297,8 +333,9 @@ static bool scan_line_continuation(scanner_state *state, TSLexer *lexer,
 
     if (lexer->lookahead == '\r') {
         lexer->advance(lexer, false);
-        if (lexer->lookahead == '\n')
+        if (lexer->lookahead == '\n') {
             lexer->advance(lexer, false);
+        }
     } else {
         lexer->advance(lexer, false);
     }
@@ -308,8 +345,8 @@ static bool scan_line_continuation(scanner_state *state, TSLexer *lexer,
 
 static bool is_parser_directive(scanner_state *state,
                                 const parser_directive *directive) {
-    if (directive->key_len == 6 &&
-        memcmp(directive->key, "escape", 6) == 0) {
+    if (directive->key_len == ESCAPE_DIRECTIVE_LEN &&
+        memcmp(directive->key, "escape", ESCAPE_DIRECTIVE_LEN) == 0) {
         if (directive->value_len != 1 || state->escape_seen ||
             (directive->value != '\\' && directive->value != '`')) {
             return false;
@@ -319,56 +356,97 @@ static bool is_parser_directive(scanner_state *state,
         return true;
     }
 
-    return directive->value_len > 0 &&
-           ((directive->key_len == 6 &&
-             memcmp(directive->key, "syntax", 6) == 0) ||
-            (directive->key_len == 5 &&
-             memcmp(directive->key, "check", 5) == 0));
+    if (directive->value_len == 0) {
+        return false;
+    }
+    if (directive->key_len == SYNTAX_DIRECTIVE_LEN &&
+        memcmp(directive->key, "syntax", SYNTAX_DIRECTIVE_LEN) == 0) {
+        return true;
+    }
+
+    return (directive->key_len == CHECK_DIRECTIVE_LEN &&
+            memcmp(directive->key, "check", CHECK_DIRECTIVE_LEN) == 0) != 0;
 }
 
-static bool scan_comment(scanner_state *state, TSLexer *lexer) {
-    if (lexer->lookahead != '#')
-        return false;
-
-    bool may_be_directive = state->directive_allowed &&
-                            state->at_line_start &&
-                            lexer->get_column(lexer) == 0;
-    bool directive = false;
-    char key[16];
+static bool parse_directive_header(TSLexer *lexer, parser_directive *directive,
+                                   char *key, unsigned key_capacity) {
     unsigned key_len = 0;
     int32_t value = 0;
     unsigned value_len = 0;
 
-    lexer->advance(lexer, false);
+    while (is_directive_space(lexer->lookahead)) {
+        lexer->advance(lexer, false);
+    }
 
-    if (may_be_directive) {
-        while (is_directive_space(lexer->lookahead))
-            lexer->advance(lexer, false);
+    while (is_ascii_alpha(lexer->lookahead)) {
+        if (key_len < key_capacity) {
+            key[key_len++] = (char)to_lower_ascii(lexer->lookahead);
+        }
+        lexer->advance(lexer, false);
+    }
 
-        while ((lexer->lookahead >= 'a' && lexer->lookahead <= 'z') ||
-               (lexer->lookahead >= 'A' && lexer->lookahead <= 'Z')) {
-            if (key_len < sizeof(key)) {
-                key[key_len++] = (char)to_lower_ascii(lexer->lookahead);
-            }
+    while (is_directive_space(lexer->lookahead)) {
+        lexer->advance(lexer, false);
+    }
+
+    if (key_len < key_capacity && lexer->lookahead == '=') {
+        lexer->advance(lexer, false);
+        while (is_directive_space(lexer->lookahead)) {
             lexer->advance(lexer, false);
         }
 
-        while (is_directive_space(lexer->lookahead))
-            lexer->advance(lexer, false);
-
-        if (key_len < sizeof(key) && lexer->lookahead == '=') {
-            lexer->advance(lexer, false);
-            while (is_directive_space(lexer->lookahead))
-                lexer->advance(lexer, false);
-
-            while (!is_line_end(lexer) &&
-                   !is_directive_space(lexer->lookahead)) {
-                if (value_len == 0) {
-                    value = lexer->lookahead;
-                }
-                value_len++;
-                lexer->advance(lexer, false);
+        while (!is_line_end(lexer) &&
+               !is_directive_space(lexer->lookahead)) {
+            if (value_len == 0) {
+                value = lexer->lookahead;
             }
+            value_len++;
+            lexer->advance(lexer, false);
+        }
+    }
+
+    directive->key = key;
+    directive->key_len = key_len;
+    directive->value = value;
+    directive->value_len = value_len;
+
+    return key_len < key_capacity;
+}
+
+static bool consume_line_end(TSLexer *lexer) {
+    if (lexer->lookahead == '\r') {
+        lexer->advance(lexer, false);
+        if (lexer->lookahead == '\n') {
+            lexer->advance(lexer, false);
+        }
+        return true;
+    }
+
+    if (lexer->lookahead == '\n') {
+        lexer->advance(lexer, false);
+        return true;
+    }
+
+    return false;
+}
+
+static bool scan_comment(scanner_state *state, TSLexer *lexer) {
+    if (lexer->lookahead != '#') {
+        return false;
+    }
+
+    bool may_be_directive = (state->directive_allowed &&
+                             state->at_line_start &&
+                             lexer->get_column(lexer) == 0) != 0;
+    bool directive = false;
+    char key[DIRECTIVE_KEY_CAPACITY];
+
+    lexer->advance(lexer, false);
+
+    if (may_be_directive) {
+        parser_directive candidate;
+        if (parse_directive_header(lexer, &candidate, key, sizeof(key))) {
+            directive = is_parser_directive(state, &candidate);
         }
     }
 
@@ -376,32 +454,11 @@ static bool scan_comment(scanner_state *state, TSLexer *lexer) {
         lexer->advance(lexer, false);
     }
 
-    bool consumed_newline = false;
-    if (lexer->lookahead == '\r') {
-        lexer->advance(lexer, false);
-        if (lexer->lookahead == '\n')
-            lexer->advance(lexer, false);
-        consumed_newline = true;
-    } else if (lexer->lookahead == '\n') {
-        lexer->advance(lexer, false);
-        consumed_newline = true;
-    }
-
-    if (may_be_directive && key_len < sizeof(key)) {
-        const parser_directive candidate = {
-            .key = key,
-            .key_len = key_len,
-            .value = value,
-            .value_len = value_len,
-        };
-        directive = is_parser_directive(state, &candidate);
-    }
-
     if (!directive && state->directive_allowed) {
         close_directive_prologue(state);
     }
 
-    state->at_line_start = consumed_newline;
+    state->at_line_start = consume_line_end(lexer);
     lexer->result_symbol = COMMENT;
     return true;
 }
@@ -409,12 +466,14 @@ static bool scan_comment(scanner_state *state, TSLexer *lexer) {
 static bool scan_marker(scanner_state *state, TSLexer *lexer) {
     skip_inline_whitespace(lexer);
 
-    if (lexer->lookahead != '<')
+    if (lexer->lookahead != '<') {
         return false;
+    }
     lexer->advance(lexer, false);
 
-    if (lexer->lookahead != '<')
+    if (lexer->lookahead != '<') {
         return false;
+    }
     lexer->advance(lexer, false);
 
     close_directive_prologue(state);
@@ -475,17 +534,22 @@ static bool scan_marker(scanner_state *state, TSLexer *lexer) {
         lexer->advance(lexer, false);
     }
 
-    if (del_idx <= 1)
+    if (del_idx <= 1) {
         return false;
+    }
 
-    delimiter[0] = stripping ? '-' : ' ';
+    delimiter[0] = ' ';
+    if (stripping) {
+        delimiter[0] = '-';
+    }
     delimiter[del_idx] = '\0';
 
     // We copy the delimiter string to the heap here since we can't store our
     // stack-allocated string in our state (which is stored on the heap).
     char *del_copy = malloc(del_idx + 1);
-    if (!del_copy)
+    if (!del_copy) {
         return false;
+    }
     memcpy(del_copy, delimiter, del_idx + 1);
 
     push_heredoc(state, del_copy);
@@ -525,8 +589,9 @@ static bool scan_content(scanner_state *state, TSLexer *lexer,
         }
     }
 
-    if (!valid_symbols[HEREDOC_LINE])
+    if (!valid_symbols[HEREDOC_LINE]) {
         return false;
+    }
 
     lexer->result_symbol = HEREDOC_LINE;
 
@@ -564,8 +629,9 @@ bool tree_sitter_containerfile_external_scanner_scan(void *payload, TSLexer *lex
 
     if (valid_symbols[REQUIRED_LINE_CONTINUATION] ||
         valid_symbols[LINE_CONTINUATION]) {
-        if (scan_line_continuation(state, lexer, valid_symbols))
+        if (scan_line_continuation(state, lexer, valid_symbols)) {
             return true;
+        }
     }
 
     if (valid_symbols[COMMENT] && scan_comment(state, lexer)) {


### PR DESCRIPTION
## Summary

- Add a project `.clang-tidy` profile for the external scanner.
- Enable clang analyzer, bugprone, CERT, performance, and portability checks with warnings treated as errors.
- Add a GitHub Actions workflow that runs clang-tidy only when `src/scanner.c`, `.clang-tidy`, or the workflow changes.

## Validation

- `clang-tidy --verify-config`
- `clang-tidy src/scanner.c -- -std=c11 -Isrc`
- `actionlint .github/workflows/clang-tidy.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added static analysis configuration to enforce code quality standards across the project.
  * Configured CI pipeline to automatically run code quality checks on relevant source files during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->