### PR TITLE
[codex] Add COPY heredoc injections by extension

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -9,3 +9,51 @@
   (heredoc_block) @injection.content)
   (#set! injection.language "bash")
   (#set! injection.include-children))
+
+((copy_instruction
+  (param)*
+  (path
+    (heredoc_marker))
+  .
+  (path) @injection.filename
+  .
+  (heredoc_block) @injection.content)
+  (#match? @injection.filename "\\.[jJ][sS][oO][nN]$")
+  (#set! injection.language "json")
+  (#set! injection.include-children))
+
+((copy_instruction
+  (param)*
+  (path
+    (heredoc_marker))
+  .
+  (path) @injection.filename
+  .
+  (heredoc_block) @injection.content)
+  (#match? @injection.filename "\\.[yY][aA]?[mM][lL]$")
+  (#set! injection.language "yaml")
+  (#set! injection.include-children))
+
+((copy_instruction
+  (param)*
+  (path
+    (heredoc_marker))
+  .
+  (path) @injection.filename
+  .
+  (heredoc_block) @injection.content)
+  (#match? @injection.filename "\\.[tT][oO][mM][lL]$")
+  (#set! injection.language "toml")
+  (#set! injection.include-children))
+
+((copy_instruction
+  (param)*
+  (path
+    (heredoc_marker))
+  .
+  (path) @injection.filename
+  .
+  (heredoc_block) @injection.content)
+  (#match? @injection.filename "\\.[xX][mM][lL]$")
+  (#set! injection.language "xml")
+  (#set! injection.include-children))

--- a/queries_test.go
+++ b/queries_test.go
@@ -3,6 +3,7 @@ package tree_sitter_containerfile_test
 import (
 	"testing"
 
+	sitter "github.com/tree-sitter/go-tree-sitter"
 	containerfile "github.com/wharflab/tree-sitter-containerfile"
 )
 
@@ -58,5 +59,112 @@ func TestInjectionsQueryCompiles(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected injection.content capture, got: %v", names)
+	}
+}
+
+func TestCopyHeredocInjectionsByDestinationExtension(t *testing.T) {
+	source := []byte(`FROM scratch
+COPY <<EOF /etc/config.json
+{"ok": true}
+EOF
+COPY --chmod=644 <<EOF ./config.yaml
+ok: true
+EOF
+COPY <<EOF ./config.yml
+ok: yes
+EOF
+COPY <<EOF ./Cargo.toml
+[package]
+name = "demo"
+EOF
+COPY <<EOF ./feed.xml
+<root />
+EOF
+COPY <<EOF ./notes.txt
+plain text
+EOF
+`)
+
+	language := containerfile.GetLanguage()
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatalf("set language: %v", err)
+	}
+
+	tree := parser.Parse(source, nil)
+	defer tree.Close()
+	if tree.RootNode().HasError() {
+		t.Fatalf("source parsed with errors:\n%s", tree.RootNode().ToSexp())
+	}
+
+	query, err := containerfile.GetInjectionsQuery()
+	if err != nil {
+		t.Fatalf("injections query failed to compile: %v", err)
+	}
+	defer query.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+
+	type injection struct {
+		filename string
+		language string
+		content  string
+	}
+
+	var injections []injection
+	matches := cursor.Matches(query, tree.RootNode(), source)
+	captureNames := query.CaptureNames()
+	for match := matches.Next(); match != nil; match = matches.Next() {
+		var item injection
+		for _, property := range query.PropertySettings(match.PatternIndex) {
+			if property.Key == "injection.language" && property.Value != nil {
+				item.language = *property.Value
+			}
+		}
+		if item.language == "" {
+			continue
+		}
+
+		for _, capture := range match.Captures {
+			switch captureNames[capture.Index] {
+			case "injection.filename":
+				item.filename = capture.Node.Utf8Text(source)
+			case "injection.content":
+				item.content = capture.Node.Utf8Text(source)
+			}
+		}
+		injections = append(injections, item)
+	}
+
+	expected := map[string]string{
+		"/etc/config.json": "json",
+		"./config.yaml":    "yaml",
+		"./config.yml":     "yaml",
+		"./Cargo.toml":     "toml",
+		"./feed.xml":       "xml",
+	}
+
+	if len(injections) != len(expected) {
+		t.Fatalf("expected %d COPY heredoc injections, got %d: %#v", len(expected), len(injections), injections)
+	}
+
+	for _, injection := range injections {
+		language, ok := expected[injection.filename]
+		if !ok {
+			t.Fatalf("unexpected injection for %q: %#v", injection.filename, injection)
+		}
+		if injection.language != language {
+			t.Errorf("expected %s injection for %q, got %s", language, injection.filename, injection.language)
+		}
+		if injection.content == "" {
+			t.Errorf("expected heredoc content capture for %q", injection.filename)
+		}
+		delete(expected, injection.filename)
+	}
+
+	for filename, language := range expected {
+		t.Errorf("missing %s injection for %q", language, filename)
 	}
 }


### PR DESCRIPTION
## Summary

Adds injection query support for `COPY <<EOF <destination>` heredocs where the destination filename has one of the supported structured-data extensions.

Supported injections:
- JSON: `.json`
- YAML: `.yaml`, `.yml`
- TOML: `.toml`
- XML: `.xml`

The query patterns capture the COPY heredoc body and gate the injected language by destination extension. A targeted Go test now parses COPY heredoc examples and verifies that only supported extensions produce injection matches.

## Validation

- `go test ./...`
- `npx tree-sitter test`
- `npm test`