### PR TITLE
fix: stop combining RUN shell commands into one bash injection (#27)

### DIFF
--- a/.github/workflows/go-compat.yml
+++ b/.github/workflows/go-compat.yml
@@ -29,5 +29,8 @@ jobs:
         with:
           go-version: stable
 
+      - name: Run Go unit tests (grammar bindings and queries)
+        run: CGO_ENABLED=1 go test ./...
+
       - name: Run Go compatibility acceptance test
         run: bash go-compat/acceptance.sh

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,9 +1,13 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
 
+; Each shell_command is its own bash document. Do NOT add
+; (#set! injection.combined): it would parse every RUN body in the file as a
+; single bash document, so the trailing token of one RUN fuses with the leading
+; command word of the next (e.g. "migrations.sh" + "bundle"), breaking command
+; highlighting from the second RUN onward. See issue #27.
 ((shell_command) @injection.content
-  (#set! injection.language "bash")
-  (#set! injection.combined))
+  (#set! injection.language "bash"))
 
 ((run_instruction
   (heredoc_block) @injection.content)

--- a/queries_test.go
+++ b/queries_test.go
@@ -1,6 +1,7 @@
 package tree_sitter_containerfile_test
 
 import (
+	"strings"
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -166,5 +167,95 @@ EOF
 
 	for filename, language := range expected {
 		t.Errorf("missing %s injection for %q", language, filename)
+	}
+}
+
+// TestShellCommandInjectionsAreNotCombined guards against a regression of
+// issue #27. The bash injection for shell_command must NOT use
+// (#set! injection.combined): combining merges every RUN body in the file into
+// a single bash document, so the trailing token of one RUN fuses with the
+// leading command word of the next (e.g. "migrations.sh" + "bundle"), and every
+// command from the second RUN onward loses its highlighting. Each shell_command
+// must instead inject as its own document.
+func TestShellCommandInjectionsAreNotCombined(t *testing.T) {
+	// Mirrors the reproduction from issue #27: two RUN instructions separated
+	// by a COPY. The first RUN ends in "migrations.sh"; the second starts with
+	// "bundle". With injection.combined they would parse as one bash document.
+	source := []byte(`ARG IMAGE_TAG
+FROM $IMAGE_TAG
+
+RUN chmod +x \
+    /entrypoints/kafka-consumer.sh \
+    /entrypoints/migrations.sh
+
+COPY . /app
+
+RUN bundle install --jobs $(nproc)
+`)
+
+	language := containerfile.GetLanguage()
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatalf("set language: %v", err)
+	}
+
+	tree := parser.Parse(source, nil)
+	defer tree.Close()
+	if tree.RootNode().HasError() {
+		t.Fatalf("source parsed with errors:\n%s", tree.RootNode().ToSexp())
+	}
+
+	query, err := containerfile.GetInjectionsQuery()
+	if err != nil {
+		t.Fatalf("injections query failed to compile: %v", err)
+	}
+	defer query.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+
+	captureNames := query.CaptureNames()
+	var bashRegions []string
+	matches := cursor.Matches(query, tree.RootNode(), source)
+	for match := matches.Next(); match != nil; match = matches.Next() {
+		var language string
+		combined := false
+		for _, property := range query.PropertySettings(match.PatternIndex) {
+			switch property.Key {
+			case "injection.language":
+				if property.Value != nil {
+					language = *property.Value
+				}
+			case "injection.combined":
+				combined = true
+			}
+		}
+		if language != "bash" {
+			continue
+		}
+		if combined {
+			t.Errorf("bash injection must not set injection.combined (issue #27); "+
+				"combining fuses adjacent RUN bodies into one document")
+		}
+		for _, capture := range match.Captures {
+			if captureNames[capture.Index] == "injection.content" {
+				bashRegions = append(bashRegions, capture.Node.Utf8Text(source))
+			}
+		}
+	}
+
+	// Each RUN body (shell_command) must be its own injected region. The
+	// heredoc-based bash injection does not fire here, so exactly the two
+	// shell_command bodies are expected.
+	if len(bashRegions) != 2 {
+		t.Fatalf("expected 2 separate bash injection regions, got %d: %#v", len(bashRegions), bashRegions)
+	}
+
+	// Sanity-check that the two RUN bodies remained distinct documents: the
+	// second region must begin with the "bundle" command word rather than being
+	// glued onto the first region's trailing "migrations.sh".
+	if !strings.HasPrefix(strings.TrimSpace(bashRegions[1]), "bundle") {
+		t.Errorf("second bash region should start with the \"bundle\" command, got %q", bashRegions[1])
 	}
 }

--- a/test/corpus/run.txt
+++ b/test/corpus/run.txt
@@ -212,3 +212,28 @@ EOF
       (heredoc_marker))
     (heredoc_block
       (heredoc_end))))
+
+==================
+Multiple runs stay separate shell commands (issue #27)
+==================
+
+RUN chmod +x \
+    /entrypoints/kafka-consumer.sh \
+    /entrypoints/migrations.sh
+
+COPY . /app
+
+RUN bundle install --jobs $(nproc)
+
+---
+
+(source_file
+  (run_instruction
+    (shell_command
+      (line_continuation)
+      (line_continuation)))
+  (copy_instruction
+    (path)
+    (path))
+  (run_instruction
+    (shell_command)))


### PR DESCRIPTION
## Summary

Fixes #27 — commands in every `RUN` after the first were not highlighted (e.g. `bundle` rendered as plain text while `chmod` in an earlier `RUN` was highlighted as a command).

## Root cause

`queries/injections.scm` injected `bash` into `shell_command` with `(#set! injection.combined)`. Per the [tree-sitter docs](https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting#language-injection), `injection.combined` means *"all the matching nodes in the tree should have their content parsed as **one** nested document."*

So **every** `RUN` body in the file was concatenated into a single bash document, with the parser skipping the bytes in between. The first `RUN`'s trailing token became adjacent to the next `RUN`'s first token — `…migrations.sh` + `bundle` → `migrations.shbundle` — so `bundle` was no longer the command word and bash highlighting never tagged it. (`nproc` inside `$(…)` still highlighted because it sits deeper in its own subshell.)

Combining was never needed here: each `(shell_command)` match already captures one complete `RUN` body. Each `RUN` is also a separate shell process, so combining is semantically wrong too. The tree-sitter maintainers describe the same class of breakage ("text in-between two injected regions") in [tree-sitter#3517](https://github.com/tree-sitter/tree-sitter/issues/3517).

## Fix

Remove `(#set! injection.combined)` so each `shell_command` injects as its own bash document. A comment is left in `injections.scm` documenting why it must not be re-added.

### Before / after (`tree-sitter highlight`)

```
# before: bundle is plain text
RUN chmod  +x …          chmod  -> @function ✓
RUN bundle install …     bundle -> (none)    ✗

# after: bundle highlights like chmod
RUN chmod  +x …          chmod  -> @function ✓
RUN bundle install …     bundle -> @function ✓
```

## Tests

- **`queries_test.go` → `TestShellCommandInjectionsAreNotCombined`**: parses the issue-#27 sample and asserts the bash injection yields **two separate** `injection.content` regions and carries **no `injection.combined`** property. Verified it **fails** when the directive is reintroduced and **passes** with the fix.
- **`test/corpus/run.txt`**: new corpus case proving two `RUN` blocks (separated by a `COPY`) parse as two distinct `shell_command` nodes.
- **`.github/workflows/go-compat.yml`**: added `go test ./...` — the Go query tests previously ran in **no** CI workflow, so this wires the regression guard into CI.

All 161 corpus parses and the Go test suite pass.

> [!NOTE]
> A native `tree-sitter test` highlight test (`test/highlight/*` with `^`/`<-` assertions) was intentionally **not** used: the bash injection isn't resolved in that harness, and [tree-sitter#5645](https://github.com/tree-sitter/tree-sitter/issues/5645) (fix unreleased as of v0.26.9, the pinned CLI) makes a mismatched highlight assertion OOM/hang instead of failing cleanly. The Go binding tests assert the same invariant reliably and without extra dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect merging of multiple RUN instructions in container files. Each shell command is now properly processed separately, improving parsing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->